### PR TITLE
Build refinements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v2.5.0
         with:
           node-version: 16
-
+      
       - name: Install Node modules
         run: npm install
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: Build and push package to GitHub
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   create-package:
@@ -13,21 +13,23 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
-      
-    - name: Setup NodeJS
-      uses: actions/setup-node@v2.5.0
-      with:
-        node-version: 16
-        registry-url: 'https://npm.pkg.github.com'
+      - uses: actions/checkout@v2
 
-    - name: Install Node modules
-      run: npm install
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: 16
+          registry-url: "https://npm.pkg.github.com"
 
-    - name: Build library
-      run: npm run build
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1.9.0
+        with:
+          dotnet-version: 6.0.x
 
-    - name: Publish package
-      run: npm publish
-      env:
-       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build component library
+        run: dotnet msbuild -target:"CreatePublishedModule"
+
+      - name: Publish package
+        run: npm publish ./publish/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+[Pp]ublish/
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/smallsonline-core.proj
+++ b/smallsonline-core.proj
@@ -1,0 +1,80 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <Publish_Path>$(MSBuildProjectDirectory)\publish</Publish_Path>
+        <NodeModules_Path>$(MSBuildProjectDirectory)\node_modules</NodeModules_Path>
+        <PackageLock_Path>$(MSBuildProjectDirectory)\package-lock.json</PackageLock_Path>
+        <Dist_Path>$(MSBuildProjectDirectory)\dist</Dist_Path>
+        <ReinitForce>false</ReinitForce>
+    </PropertyGroup>
+
+    <Target Name="NpmReinit">
+        <Message Text="Starting re-initialization of NPM packages" Importance="high" />
+        <Message Text="---------" Importance="high" />
+        <Message Text="%0D%0A" Importance="high" />
+
+        <Warning Text="You must set the property for 'ReinitForce' to true." Condition="'$(ReinitForce)' == 'false'" />
+
+        <CallTarget Targets="NpmCleanNodeModules;NpmCleanPackageLock;NpmInstall" Condition="'$(ReinitForce)' == 'true'" />
+    </Target>
+
+    <Target Name="NpmCleanNodeModules">
+        <Message Text="- Removing -> $(NodeModules_Path)" Importance="high" />
+        <RemoveDir Directories="$(NodeModules_Path)" Condition="Exists('$(NodeModules_Path)')" />
+    </Target>
+
+    <Target Name="NpmCleanPackageLock">
+        <Message Text="- Removing -> $(PackageLock_Path)" Importance="high" />
+        <Delete Files="$(PackageLock_Path)" Condition="Exists('$(PackageLock_Path)')" />
+    </Target>
+
+    <Target Name="NpmInstall">
+        <Message Text="- Running command -> npm install" Importance="high" />
+
+        <Exec Command="npm install &gt; NUL" />
+    </Target>
+
+    <Target Name="CompileTypescript">
+        <Message Text="- Compiling Typescript code" Importance="high" />
+        <Exec Command="npm run build &gt; NUL" />
+    </Target>
+
+    <Target Name="CreatePublishedModule">
+        <Message Text="Starting to compile the module" Importance="high" />
+        <Message Text="---------" Importance="high" />
+        <Message Text="" Importance="high" />
+
+        <RemoveDir Directories="$(Publish_Path)" Condition="Exists('$(Publish_Path)')" />
+        <MakeDir Directories="$(Publish_Path)" />
+
+        <CallTarget Targets="NpmInstall" />
+        <!--
+            # Gonna have NPM run install anyway, but I'm going to leave this here for the time being.
+        <CallTarget Targets="NpmInstall" Condition="(!Exists('$(NodeModules_Path)') And !Exists('$(PackageLock_Path)')) Or (!Exists('$(NodeModules_Path)'))" />
+        -->
+
+        <CallTarget Targets="CompileTypeScript" />
+        <ItemGroup>
+            <DistDirFiles Include="$(Dist_Path)\**\*.*" />
+            <PackageFiles Include="$(MSBuildProjectDirectory)\package.json;$(MSBuildProjectDirectory)\README.md;$(MSBuildProjectDirectory)\LICENSE" />
+        </ItemGroup>
+
+        <Message Text="- Copying -> Compiled TypeScript files" Importance="high" />
+            <Message Text="@(DistDirFiles->'%09- .\dist\%(Filename)%(Extension) -> .\publish\dist\%(RecursiveDir)%(Filename)%(Extension)', '%0D%0A')" Importance="high" />
+        <Copy
+            SourceFiles="@(DistDirFiles)"
+            DestinationFiles="@(DistDirFiles->'$(Publish_Path)\dist\%(RecursiveDir)%(Filename)%(Extension)')"
+        />
+
+        <Message Text="- Copying other package files" Importance="high" />
+        <Message Text="@(PackageFiles->'%09- .\%(Filename)%(Extension) -> .\publish\%(Filename)%(Extension)', '%0D%0A')" Importance="high" />
+        <Copy
+            SourceFiles="@(PackageFiles)"
+            DestinationFiles="@(PackageFiles->'$(Publish_Path)\%(RecursiveDir)%(Filename)%(Extension)')"
+        />
+
+        <Message Text="Module compiled." Importance="high" />
+        <Message Text="---------" Importance="high" />
+        <Message Text="%0D%0A" Importance="high" />
+        <Message Text="Compiled path -> $(Publish_Path)" Importance="high" />
+    </Target>
+</Project>


### PR DESCRIPTION
Changing the build process by utilizing MSBuild. It's still using NPM and the TypeScript compiler for all of the actions, but this does help me simplify my building process and helps create the `publish/` directory for developing locally (Using `npm link` while testing the components without having to deal with `react` and `react-dom` conflicting in the process).